### PR TITLE
Indicate name and path of current file

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,6 @@ use std::cell::Cell;
 use std::path::PathBuf;
 
 use gtk::prelude::*;
-use relm4::actions::{AccelsPlus, RelmAction, RelmActionGroup};
 use relm4::prelude::*;
 use relm4_components::open_button::{OpenButton, OpenButtonSettings};
 use relm4_components::open_dialog::OpenDialogSettings;
@@ -10,6 +9,7 @@ use relm4_components::save_dialog::{
     SaveDialog, SaveDialogMsg, SaveDialogResponse, SaveDialogSettings,
 };
 
+mod actions;
 mod content;
 mod settings;
 
@@ -150,39 +150,5 @@ impl SimpleComponent for AppModel {
 
     fn shutdown(&mut self, widgets: &mut Self::Widgets, _output: relm4::Sender<Self::Output>) {
         Self::save_window_state(&widgets);
-    }
-}
-
-impl AppModel {
-    fn create_actions(
-        widgets: &<Self as SimpleComponent>::Widgets,
-        sender: &ComponentSender<Self>
-    ) {
-        let app = relm4::main_adw_application();
-
-        relm4::new_action_group!(AppActions, "app");
-        let mut app_actions = RelmActionGroup::<AppActions>::new();
-
-        relm4::new_stateless_action!(SaveAs, AppActions, "save-as");
-        let save_as = {
-            let sender = sender.clone();
-            RelmAction::<SaveAs>::new_stateless(move |_| {
-                sender.input(<Self as SimpleComponent>::Input::ShowSaveDialog);
-            })
-        };
-        app.set_accelerators_for_action::<SaveAs>(&["<primary><Shift>S"]);
-        app_actions.add_action(save_as);
-
-        relm4::new_stateless_action!(Save, AppActions, "save");
-        let save = {
-            let sender = sender.clone();
-            RelmAction::<Save>::new_stateless(move |_| {
-                sender.input(<Self as SimpleComponent>::Input::SaveCurrentFile);
-            })
-        };
-        app.set_accelerators_for_action::<Save>(&["<primary>S"]);
-        app_actions.add_action(save);
-
-        app_actions.register_for_widget(&widgets.main_window);
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -58,7 +58,7 @@ impl SimpleComponent for AppModel {
                     #[wrap(Some)]
                     set_title_widget = &adw::WindowTitle {
                         #[watch] set_title: model.opened_file_name.as_ref()
-                            .unwrap_or(&String::from("Text Editor")),
+                            .unwrap_or(&String::from("Untitled")),
                         #[watch] set_subtitle: model.opened_path_string.as_ref()
                             .unwrap_or(&String::from("")),
                     },

--- a/src/app.rs
+++ b/src/app.rs
@@ -48,9 +48,6 @@ impl SimpleComponent for AppModel {
     view! {
         main_window = adw::ApplicationWindow {
             set_title: Some("Text Editor"),
-            set_default_width: settings.int(Settings::WindowWidth.as_str()),
-            set_default_height: settings.int(Settings::WindowHeight.as_str()),
-            set_maximized: settings.boolean(Settings::WindowMaximized.as_str()),
 
             gtk::Box {
                 set_orientation: gtk::Orientation::Vertical,
@@ -74,8 +71,6 @@ impl SimpleComponent for AppModel {
         window: &Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
-        let settings = gtk::gio::Settings::new(APP_ID);
-
         let content = content::ContentModel::builder()
             .launch(content::ContentInit)
             .detach();
@@ -106,6 +101,7 @@ impl SimpleComponent for AppModel {
 
         let widgets = view_output!();
 
+        Self::load_window_state(&widgets);
         Self::create_actions(&widgets, &sender);
 
         ComponentParts { model, widgets }
@@ -171,6 +167,20 @@ impl AppModel {
             settings::Settings::WindowMaximized.as_str(),
             widgets.main_window.is_maximized(),
         );
+    }
+
+    fn load_window_state(widgets: &<Self as SimpleComponent>::Widgets) {
+        let settings = gtk::gio::Settings::new(APP_ID);
+
+        let width = settings.int(Settings::WindowWidth.as_str());
+        let height = settings.int(Settings::WindowHeight.as_str());
+
+        widgets.main_window.set_default_size(width, height);
+
+        let is_maximized = settings.boolean(Settings::WindowMaximized.as_str());
+        if is_maximized {
+            widgets.main_window.maximize();
+        }
     }
 
     fn create_actions(

--- a/src/app.rs
+++ b/src/app.rs
@@ -103,7 +103,7 @@ impl SimpleComponent for AppModel {
             content,
             open_button,
             save_dialog,
-            opened_path: None::<PathBuf>,
+            opened_path: None,
             opened_path_string: None,
             opened_file_name: None,
             toast: Cell::new(None),

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,8 +13,6 @@ use relm4_components::save_dialog::{
 mod content;
 mod settings;
 
-use settings::Settings;
-
 pub(crate) const APP_ID: &str = "com.github.tiago_vargas.text_editor";
 
 pub(crate) struct AppModel {
@@ -156,33 +154,6 @@ impl SimpleComponent for AppModel {
 }
 
 impl AppModel {
-    fn save_window_state(widgets: &<Self as SimpleComponent>::Widgets) {
-        let settings = gtk::gio::Settings::new(APP_ID);
-
-        let (width, height) = widgets.main_window.default_size();
-        let _ = settings.set_int(settings::Settings::WindowWidth.as_str(), width);
-        let _ = settings.set_int(settings::Settings::WindowHeight.as_str(), height);
-
-        let _ = settings.set_boolean(
-            settings::Settings::WindowMaximized.as_str(),
-            widgets.main_window.is_maximized(),
-        );
-    }
-
-    fn load_window_state(widgets: &<Self as SimpleComponent>::Widgets) {
-        let settings = gtk::gio::Settings::new(APP_ID);
-
-        let width = settings.int(Settings::WindowWidth.as_str());
-        let height = settings.int(Settings::WindowHeight.as_str());
-
-        widgets.main_window.set_default_size(width, height);
-
-        let is_maximized = settings.boolean(Settings::WindowMaximized.as_str());
-        if is_maximized {
-            widgets.main_window.maximize();
-        }
-    }
-
     fn create_actions(
         widgets: &<Self as SimpleComponent>::Widgets,
         sender: &ComponentSender<Self>

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1,0 +1,38 @@
+use super::AppModel;
+
+use relm4::prelude::*;
+use relm4::actions::{AccelsPlus, RelmAction, RelmActionGroup};
+
+impl AppModel {
+    pub(crate) fn create_actions(
+        widgets: &<Self as SimpleComponent>::Widgets,
+        sender: &ComponentSender<Self>
+    ) {
+        let app = relm4::main_adw_application();
+
+        relm4::new_action_group!(AppActions, "app");
+        let mut app_actions = RelmActionGroup::<AppActions>::new();
+
+        relm4::new_stateless_action!(SaveAs, AppActions, "save-as");
+        let save_as = {
+            let sender = sender.clone();
+            RelmAction::<SaveAs>::new_stateless(move |_| {
+                sender.input(<Self as SimpleComponent>::Input::ShowSaveDialog);
+            })
+        };
+        app.set_accelerators_for_action::<SaveAs>(&["<primary><Shift>S"]);
+        app_actions.add_action(save_as);
+
+        relm4::new_stateless_action!(Save, AppActions, "save");
+        let save = {
+            let sender = sender.clone();
+            RelmAction::<Save>::new_stateless(move |_| {
+                sender.input(<Self as SimpleComponent>::Input::SaveCurrentFile);
+            })
+        };
+        app.set_accelerators_for_action::<Save>(&["<primary>S"]);
+        app_actions.add_action(save);
+
+        app_actions.register_for_widget(&widgets.main_window);
+    }
+}

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -1,3 +1,8 @@
+use super::{AppModel, APP_ID};
+
+use gtk::prelude::*;
+use relm4::prelude::*;
+
 pub(crate) enum Settings {
     WindowWidth,
     WindowHeight,
@@ -10,6 +15,35 @@ impl Settings {
             Self::WindowWidth => "window-width",
             Self::WindowHeight => "window-height",
             Self::WindowMaximized => "window-maximized",
+        }
+    }
+}
+
+impl AppModel {
+    pub(super) fn save_window_state(widgets: &<Self as SimpleComponent>::Widgets) {
+        let settings = gtk::gio::Settings::new(APP_ID);
+
+        let (width, height) = widgets.main_window.default_size();
+        let _ = settings.set_int(Settings::WindowWidth.as_str(), width);
+        let _ = settings.set_int(Settings::WindowHeight.as_str(), height);
+
+        let _ = settings.set_boolean(
+            Settings::WindowMaximized.as_str(),
+            widgets.main_window.is_maximized(),
+        );
+    }
+
+    pub(super) fn load_window_state(widgets: &<Self as SimpleComponent>::Widgets) {
+        let settings = gtk::gio::Settings::new(APP_ID);
+
+        let width = settings.int(Settings::WindowWidth.as_str());
+        let height = settings.int(Settings::WindowHeight.as_str());
+
+        widgets.main_window.set_default_size(width, height);
+
+        let is_maximized = settings.boolean(Settings::WindowMaximized.as_str());
+        if is_maximized {
+            widgets.main_window.maximize();
         }
     }
 }


### PR DESCRIPTION
As the title says, both the name and the path of the currently opened file will be indicated:

![Screenshot from 2023-12-04 12-55-18](https://github.com/tiago-vargas/text-editor/assets/78927143/00561feb-64f3-4701-ad52-5912c47f0557)

If you didn't open a file yet and is just typing around, it just shows "Untitled" instead:

![Screenshot from 2023-12-04 12-54-56](https://github.com/tiago-vargas/text-editor/assets/78927143/e2070a61-9ee7-4493-997e-db7212974416)

I had to refactor some things to make it easier to reason through the code.

The code that restores and saves the window state is now part of the `settings` module.
The actions (currently "Save" and "Save As") are now part of the `actions` module.

This cleans the `app` module a lot and made it easier to modify it.